### PR TITLE
Update INSTALL.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -61,7 +61,7 @@ tar -zxf watchonly.tar.gz
 cd bitcoin-watchonly
 sudo add-apt-repository ppa:bitcoin/bitcoin
 sudo apt-get update
-sudo apt-get install libdb4.8++ libdb4.8++-dev pkg-config libprotobuf-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libminiupnpc8 minissdpd libboost1.48-* ccache
+sudo apt-get install libdb4.8++ libdb4.8++-dev pkg-config libprotobuf-dev libminiupnpc8 minissdpd libboost1.48-* ccache
 ./autogen.sh
 ./configure --without-qt
 make


### PR DESCRIPTION
Updated bitcoind apt-get install line, cause independent libboost packages implies 1.46 version dependecies: This is solved with just libboost1.48-\* install

(libboost-filesystem-dev : Depends: libboost-filesystem1.46-dev but it is not going to be installed
 libboost-program-options-dev : Depends: libboost-program-options1.46-dev but it is not going to be installed
 libboost-system-dev : Depends: libboost-system1.46-dev but it is not going to be installed
 libboost-thread-dev : Depends: libboost-thread1.46-dev but it is not going to be installed
E: Unable to correct problems, you have held broken packages.)
