### PR TITLE
Added OSX install guide link to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Coming soon:
 
 ## Get Started
 
-See the [Install Guide](https://github.com/kyledrake/coinpunk/blob/master/docs/INSTALL.md).
+See the [Install Guide](https://github.com/kyledrake/coinpunk/blob/master/docs/INSTALL.md), 
+or the [OSX Install Guide](https://github.com/kyledrake/coinpunk/blob/master/docs/INSTALL-OSX.md).
 
 ## Coinpunk is for Advanced Users
 


### PR DESCRIPTION
I found this site and started making my own OSX install guide, until I realized that one already existed, but wasn't linked to from the main readme file.
